### PR TITLE
fix matrix column selection in predict.mclogit if there is only one predictor left.

### DIFF
--- a/pkg/R/mclogit.R
+++ b/pkg/R/mclogit.R
@@ -404,7 +404,7 @@ predict.mclogit <- function(object, newdata=NULL,type=c("link","response"),se.fi
                       )
 
     cf <- coef(object)
-    X <- X[,names(cf)]
+    X <- X[,names(cf), drop=FALSE]
     
     eta <- c(X %*% coef(object))
     if(se.fit){


### PR DESCRIPTION
Without `drop=FALSE` column selection for a single predictor returns a simple vector, which is unsuitable for the multiplication in the next line.