### PR TITLE
Fixed dynamic formulas in mblogit with random effect

### DIFF
--- a/pkg/R/mblogit.R
+++ b/pkg/R/mblogit.R
@@ -118,7 +118,13 @@ mblogit <- function(formula,
         mt <- attr(mf0,"terms")
         rf <- paste(c(".~.",all.vars(random)),collapse="+")
         rf <- as.formula(rf)
-        mff <- structure(mf$formula,class="formula")
+        if (typeof(mf$formula) == "symbol") {
+          mff <- formula
+        }
+        else {
+          mff <- structure(mf$formula,class="formula")
+        }
+        mff <- eval(mff, parent.frame())
         mf$formula <- update(mff,rf)
         mf <- eval(mf, parent.frame())
     }


### PR DESCRIPTION
Dear Prof. Dr. Martin Elff,

My name is Ilya Yalchyk, I'm a master student in the University of Bonn, and a research assistant in Fraunhofer SCAI. I'm using your library for our research for Alzheimer's disease.

I've noticed a problem that made it hard for me to use your library. Let's consider an example with a random effect:
```R
library(MASS)
house.mblogit <- mblogit(Sat ~ Infl + Cont, weights = Freq, data = housing, random = ~1|Type)
```
It converges.

But if we change the way how we provide the formula:
```R
house.mblogit <- mblogit(as.formula("Sat ~ Infl + Cont"), weights = Freq, data = housing, random = ~1|Type)
```
It produces the following error:
> Error in terms.formula(tmp, simplify = TRUE): invalid model formula in ExtractVars

If we provide the formula as a variable:
```R
f <- Sat ~ Infl + Cont
house.mblogit <- mblogit(f, weights = Freq, data = housing, random = ~1|Type)
```
It produces another error:
> Error in attributes(.Data) <- c(attributes(.Data), attrib): cannot set attribute on a symbol

In this pull request, I suggest a simple fix for this problem. I hope it will be useful.


Yours sincerely,
Ilya Yalchyk