### PR TITLE
Add emmeans support

### DIFF
--- a/pkg/DESCRIPTION
+++ b/pkg/DESCRIPTION
@@ -19,6 +19,7 @@ Imports:
     memisc,
     methods
 Suggests:
+    emmeans,
     MASS,
     nnet
 LazyLoad: Yes

--- a/pkg/DESCRIPTION
+++ b/pkg/DESCRIPTION
@@ -20,7 +20,9 @@ Imports:
     methods
 Suggests:
     emmeans,
+    estimability,
     MASS,
+    mvtnorm,
     nnet
 LazyLoad: Yes
 URL: http://mclogit.elff.eu,https://github.com/melff/mclogit/

--- a/pkg/R/emmeans.R
+++ b/pkg/R/emmeans.R
@@ -1,0 +1,25 @@
+### emmeans support for mblogit and mmblogit models
+
+recover_data.mblogit <- function(object, ...) {
+    rd <- get("recover_data.multinom", asNamespace("emmeans"))
+    rd(object, ...)
+}
+
+emm_basis.mblogit <- function(object, trms, xlev, grid, 
+                              mode = c("prob", "latent"), vcov., ...) {
+    object$coefficients <- object$coefmat
+    object$lev <- levels(object$model[[1]])
+    object$edf <- Inf
+    # we have to rearrange the vcov elements in row-major order
+    if(missing(vcov.))
+        vcov. <- vcov(object)
+    perm <- matrix(seq_along(as.numeric(object$coefmat)), 
+                  ncol = ncol(object$coefmat))
+    perm <- as.numeric(t(perm))
+    vcov. <- vcov.[perm, perm]
+    emb <- get("emm_basis.multinom", asNamespace("emmeans"))
+    emb(object, trms = trms, xlev = xlev, grid = grid, mode = mode, vcov. = vcov., ...)
+}
+
+### Documentation & example: See emmeans-support.Rd
+

--- a/pkg/R/emmeans.R
+++ b/pkg/R/emmeans.R
@@ -1,24 +1,79 @@
 ### emmeans support for mblogit and mmblogit models
 
 recover_data.mblogit <- function(object, ...) {
-    rd <- get("recover_data.multinom", asNamespace("emmeans"))
-    rd(object, ...)
+    fcall <- object$call
+    emmeans::recover_data(fcall, delete.response(terms(object)), object$na.action, ...)
 }
 
 emm_basis.mblogit <- function(object, trms, xlev, grid, 
-                              mode = c("prob", "latent"), vcov., ...) {
-    object$coefficients <- object$coefmat
-    object$lev <- levels(object$model[[1]])
-    object$edf <- Inf
-    # we have to rearrange the vcov elements in row-major order
-    if(missing(vcov.))
-        vcov. <- vcov(object)
+                              mode = c("prob", "latent"), ...) {
+    mode <- match.arg(mode)
+    bhat <- t(object$coefmat)
+    V <- emmeans::.my.vcov(object, ...)
+    # we have to rearrange the vcov elements in row-major order...
     perm <- matrix(seq_along(as.numeric(object$coefmat)), 
-                  ncol = ncol(object$coefmat))
+                   ncol <- ncol(object$coefmat))
     perm <- as.numeric(t(perm))
-    vcov. <- vcov.[perm, perm]
-    emb <- get("emm_basis.multinom", asNamespace("emmeans"))
-    emb(object, trms = trms, xlev = xlev, grid = grid, mode = mode, vcov. = vcov., ...)
+    V <- V[perm, perm]
+    k <- ifelse(is.matrix(object$coefmat), ncol(bhat), 1)
+    m <- model.frame(trms, grid, na.action = na.pass, xlev = xlev)
+    X <- model.matrix(trms, m, contrasts.arg = object$contrasts)
+    # recenter for latent predictions
+    pat <- (rbind(0, diag(k + 1, k)) - 1) / (k + 1)
+    X <- kronecker(pat, X)
+    nbasis <- estimability::all.estble
+    nbasis <- kronecker(rep(1,k), nbasis)
+    misc <- list(tran = "log", inv.lbl = "e^y")
+    dfargs <- list(df = Inf)
+    dffun <- function(k, dfargs) dfargs$df
+    ylevs <- list(class = levels(object$model[[1]]))
+    if (is.null(ylevs)) 
+        ylevs <- list(class = seq_len(k))
+    names(ylevs) <- as.character.default(eval(object$call$formula, environment(trms))[[2]])
+    misc$ylevs <- ylevs
+    if (mode == "prob")
+        misc$postGridHook <- .multinom.postGrid
+    list(X = X, bhat = as.numeric(bhat), nbasis = nbasis, V = V, 
+         dffun = dffun, dfargs = dfargs, misc = misc)
+}
+
+
+### post-processing when mode = "prob" (copied from emmeans support for "multinom" objects)
+.multinom.postGrid <- function(object, N.sim, ...) {
+    linfct <- object@linfct
+    misc <- object@misc
+    # grid will have multresp as slowest-varying factor...
+    idx <- matrix(seq_along(linfct[, 1]), 
+                 ncol = length(object@levels[[object@roles$multresp]]))
+    bhat <- as.numeric(idx) # right length, contents will be replaced
+    if(sim <- !missing(N.sim)) {
+        message("Simulating a sample of size ", N.sim)
+        bsamp <- mvtnorm::rmvnorm(N.sim, object@bhat, object@V)
+        postb <- matrix(0, nrow = N.sim, ncol = length(bhat))
+    }
+    for (i in 1:nrow(idx)) {
+        rows <- idx[i, ]
+        exp.psi <- exp(linfct[rows, , drop = FALSE] %*% object@bhat)
+        p <- as.numeric(exp.psi / sum(exp.psi))
+        bhat[rows] <- p
+        if (sim) {
+            ex <- exp(linfct[rows, , drop = FALSE] %*% t(bsamp))  # p x N
+            px <- t(apply(ex, 2, function(x) x / sum(x)))
+            postb[, rows] <- px
+        }
+        A <- emmeans::.diag(p) - outer(p, p)    # partial derivs
+        linfct[rows, ] <- A %*% linfct[rows, ]
+    }
+    misc$postGridHook <- misc$tran <- misc$inv.lbl <- NULL
+    misc$estName <- "prob"
+    
+    object@bhat <- bhat
+    object@V <- linfct %*% tcrossprod(object@V, linfct)
+    object@linfct <- diag(1, length(bhat))
+    object@misc <- misc
+    if (sim)
+        object@post.beta <- postb
+    object
 }
 
 ### Documentation & example: See emmeans-support.Rd

--- a/pkg/R/zzz.R
+++ b/pkg/R/zzz.R
@@ -30,6 +30,9 @@
     )    
   }
   
+  if (requireNamespace("emmeans", quietly = TRUE))
+    emmeans::.emm_register(c("mblogit"), pkg)
+  
   options(mblogit.basecat.sep="/")
   options(mblogit.show.basecat=TRUE)
   options(summary.stats.mclogit=c("Deviance","N"))

--- a/pkg/man/emmeans-support.Rd
+++ b/pkg/man/emmeans-support.Rd
@@ -7,14 +7,23 @@
   optional \code{mode} argument allows for choosing two modes of estimation:
   \code{"prob"} (the default), which provides estimated multinomial
   probabilities, and \code{"latent"}, which provides the linear predictor, on
-  the log scale. These operate the same way as for \code{nnet::multinom}
-  models.
+  the log scale. For either mode, the variables in the reference grid comprise the
+  predictors in the right-hand side of the model, plus the response variable
+  (whose levels delineate the multinomial responses).
+  
+  With \code{mode = "prob"}, the user may optionally specify an iteger value for
+  \code{N.sim}, in which case responses are simulated using the model equation.
+  The \code{emmeans} results are then summarized using the simulated values
+  as if it were a model fitted by MCMC methods.
 }
 \examples{
 if (requireNamespace("MASS") && requireNamespace("emmeans")) {
   house.mbl <- mblogit(Sat ~ Type + Infl, weights = Freq,
       data = MASS::housing)
-  emmeans::emmeans(house.mbl, ~ Sat | Type, mode = "prob")
+  print(emmeans::emmeans(house.mbl, ~ Sat | Type)) # defaults to mode = "prob"
+  
+  set.seed(123)
+  emmeans::emmeans(house.mbl, ~ Sat | Type, N.sim = 1000)
 }
 }
 

--- a/pkg/man/emmeans-support.Rd
+++ b/pkg/man/emmeans-support.Rd
@@ -1,0 +1,23 @@
+\name{emmeans-support}
+\alias{emmeans-support}
+\title{emmeans support for \code{mblogit} models}
+\description{
+  Support for \code{mblogit} and \code{mmblogit} models is provided
+  for interfacing with the \bold{emmeans} package, if it is installed. An
+  optional \code{mode} argument allows for choosing two modes of estimation:
+  \code{"prob"} (the default), which provides estimated multinomial
+  probabilities, and \code{"latent"}, which provides the linear predictor, on
+  the log scale. These operate the same way as for \code{nnet::multinom}
+  models.
+}
+\examples{
+if (requireNamespace("MASS") && requireNamespace("emmeans")) {
+  house.mbl <- mblogit(Sat ~ Type + Infl, weights = Freq,
+      data = MASS::housing)
+  emmeans::emmeans(house.mbl, ~ Sat | Type, mode = "prob")
+}
+}
+
+
+
+


### PR DESCRIPTION
Hello,

This PR adds methods so that the **emmeans** package may be used with `mblogit` and `mmblogit` objects. Actually, that package contains its own preliminary support, and this PR duplicates that support. Any changes you make will override the internal **emmeans** methods. 

I also provided an example under `? "emmeans-support"`. 

It is better if you incorporate this code in your own package because you understand the structure of your model objects, and I may very well have overlooked something. I already know that, nominally, these methods also seem to run for `mclogit` objects, but I'm not sure it is correct or complete. I am more than happy to answer any questions

You may also wish to take a look at a user request https://github.com/rvlenth/emmeans/issues/268